### PR TITLE
ci(workflows): trigger CI on release-plz branch pushes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, release-plz-*]
   pull_request:
 
 env:


### PR DESCRIPTION
## Problem

PR #22 (release-plz bot) has permanently pending CI checks. GitHub Actions won't trigger `pull_request` workflows on PRs created by `GITHUB_TOKEN` — this is an intentional safety measure to prevent infinite workflow loops.

## Fix

Add `release-plz-*` to the CI `push` trigger. When release-plz pushes to its branch, CI runs via the `push` event, and GitHub associates the check results with the PR through the commit SHA.

```diff
 on:
   push:
-    branches: [main]
+    branches: [main, release-plz-*]
   pull_request:
```

## Effect

After merging, the next time release-plz creates/updates a PR, all CI jobs (lint, test, docs, build, quality gate) will run and show up on the PR.