### PR TITLE
feat(db): database migrations and project repository

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -106,8 +106,24 @@ version = "0.2.1"
 dependencies = [
  "chrono",
  "serde",
+ "sqlx",
  "strum",
  "thiserror 2.0.18",
+ "uuid",
+]
+
+[[package]]
+name = "alpe-db"
+version = "0.2.1"
+dependencies = [
+ "alpe-core",
+ "alpe-test",
+ "chrono",
+ "serde_json",
+ "sqlx",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
  "uuid",
 ]
 
@@ -185,6 +201,8 @@ name = "alpe-test"
 version = "0.2.1"
 dependencies = [
  "alpe-core",
+ "alpe-db",
+ "chrono",
  "reqwest",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "crates/alpe-api",
     "crates/alpe-auth",
     "crates/alpe-cli",
+    "crates/alpe-db",
     "crates/alpe-sdk",
     "crates/alpe-test",
     "crates/alpe-operator-db",
@@ -76,6 +77,7 @@ dirs = "6.0.0"
 # Internal crates (path for local dev, version for crates.io publishing)
 alpe-core = { path = "crates/alpe-core", version = "0.2.1" }
 alpe-auth = { path = "crates/alpe-auth", version = "0.2.1" }
+alpe-db = { path = "crates/alpe-db", version = "0.2.1" }
 alpe-sdk = { path = "crates/alpe-sdk", version = "0.2.1" }
 alpe-test = { path = "crates/alpe-test" }
 

--- a/crates/alpe-core/Cargo.toml
+++ b/crates/alpe-core/Cargo.toml
@@ -8,9 +8,14 @@ license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 
+[features]
+default = []
+db = ["dep:sqlx"]
+
 [dependencies]
 chrono = { workspace = true }
 serde = { workspace = true }
+sqlx = { workspace = true, optional = true }
 strum = { workspace = true }
 thiserror = { workspace = true }
 uuid = { workspace = true }

--- a/crates/alpe-core/src/jurisdiction.rs
+++ b/crates/alpe-core/src/jurisdiction.rs
@@ -116,6 +116,40 @@ pub enum Jurisdiction {
     SE,
 }
 
+// ── sqlx integration (behind the `db` feature) ──
+//
+// Maps the Rust `Jurisdiction` enum to the Postgres `jurisdiction_type` enum.
+// We delegate to the `strum::Display` / `FromStr` impls so the Postgres values
+// ('EU', 'AT', 'BE', …) stay in sync with the Rust variants automatically.
+#[cfg(feature = "db")]
+mod db_impls {
+    use super::Jurisdiction;
+
+    impl sqlx::Type<sqlx::Postgres> for Jurisdiction {
+        fn type_info() -> sqlx::postgres::PgTypeInfo {
+            sqlx::postgres::PgTypeInfo::with_name("jurisdiction_type")
+        }
+    }
+
+    impl sqlx::Encode<'_, sqlx::Postgres> for Jurisdiction {
+        fn encode_by_ref(
+            &self,
+            buf: &mut sqlx::postgres::PgArgumentBuffer,
+        ) -> Result<sqlx::encode::IsNull, sqlx::error::BoxDynError> {
+            let s = self.to_string();
+            <String as sqlx::Encode<sqlx::Postgres>>::encode(s, buf)
+        }
+    }
+
+    impl<'r> sqlx::Decode<'r, sqlx::Postgres> for Jurisdiction {
+        fn decode(value: sqlx::postgres::PgValueRef<'r>) -> Result<Self, sqlx::error::BoxDynError> {
+            let s = <String as sqlx::Decode<sqlx::Postgres>>::decode(value)?;
+            s.parse::<Self>()
+                .map_err(|e| Box::new(e) as sqlx::error::BoxDynError)
+        }
+    }
+}
+
 impl Jurisdiction {
     /// Returns `true` if this jurisdiction represents a specific country
     /// (i.e. not the EU umbrella).

--- a/crates/alpe-db/Cargo.toml
+++ b/crates/alpe-db/Cargo.toml
@@ -1,27 +1,25 @@
 [package]
-name = "alpe-test"
-description = "Shared test infrastructure for the Alpe platform (dev-dependency only)"
+name = "alpe-db"
+description = "Database migrations, connection pooling, and repository layer for the Alpe platform"
 edition.workspace = true
 version.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
-publish = false
 
 [dependencies]
-alpe-core = { workspace = true }
-alpe-db = { workspace = true }
+alpe-core = { workspace = true, features = ["db"] }
 chrono = { workspace = true }
-reqwest = { workspace = true }
-serde = { workspace = true }
 serde_json = { workspace = true }
 sqlx = { workspace = true }
-testcontainers = { workspace = true }
-testcontainers-modules = { workspace = true }
-tokio = { workspace = true }
+thiserror = { workspace = true }
 tracing = { workspace = true }
 uuid = { workspace = true }
+
+[dev-dependencies]
+alpe-test = { workspace = true }
+tokio = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/alpe-db/migrations/001_users.sql
+++ b/crates/alpe-db/migrations/001_users.sql
@@ -1,0 +1,23 @@
+-- 001_users.sql
+--
+-- Creates the `users` table. This is the foundational identity table that all
+-- other entities reference via `owner_id` foreign keys.
+--
+-- Design choices:
+--   • `id` uses `gen_random_uuid()` so the application never needs to supply a PK.
+--   • `email` is UNIQUE because it serves as the login identifier.
+--   • `password_hash` stores the Argon2id hash — never the plaintext password.
+--   • `created_at` defaults to `now()` so the DB records insertion time even if
+--     the application forgets to supply it.
+
+-- Enable pgcrypto for gen_random_uuid() on Postgres versions < 14.
+-- This is a no-op on Postgres 14+ where the function is built-in.
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+CREATE TABLE IF NOT EXISTS users (
+    id            UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+    email         TEXT        UNIQUE NOT NULL,
+    name          TEXT        NOT NULL,
+    password_hash TEXT        NOT NULL,
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT now()
+);

--- a/crates/alpe-db/migrations/002_projects.sql
+++ b/crates/alpe-db/migrations/002_projects.sql
@@ -1,0 +1,38 @@
+-- 002_projects.sql
+--
+-- Creates the Postgres `jurisdiction_type` enum and the `projects` table.
+--
+-- Design choices:
+--
+--   • jurisdiction_type is a Postgres enum (not a TEXT column) because:
+--     1. Data integrity — the DB rejects any value outside the defined set,
+--        providing a safety net even if the application has a bug.
+--     2. Storage efficiency — enums are stored as 4 bytes vs variable-length text.
+--     3. Query performance — enum comparisons are integer comparisons under the hood.
+--     The values match the `Jurisdiction` Rust enum in `alpe-core` exactly (uppercase
+--     ISO 3166-1 alpha-2 codes).
+--
+--   • UNIQUE(owner_id, name) enforces that the same user cannot have two projects
+--     with the same name, while different users CAN reuse names. This mirrors the
+--     GitHub/GitLab "namespace/project" model.
+--
+--   • `updated_at` defaults to `now()` on INSERT and must be set explicitly on UPDATE.
+
+CREATE TYPE jurisdiction_type AS ENUM (
+    'EU',
+    'AT', 'BE', 'BG', 'HR', 'CY', 'CZ', 'DK', 'EE', 'FI',
+    'FR', 'DE', 'GR', 'HU', 'IE', 'IT', 'LV', 'LT', 'LU',
+    'MT', 'NL', 'PL', 'PT', 'RO', 'SK', 'SI', 'ES', 'SE'
+);
+
+CREATE TABLE IF NOT EXISTS projects (
+    id           UUID              PRIMARY KEY DEFAULT gen_random_uuid(),
+    name         TEXT              NOT NULL,
+    jurisdiction jurisdiction_type NOT NULL,
+    owner_id     UUID              NOT NULL REFERENCES users(id),
+    created_at   TIMESTAMPTZ       NOT NULL DEFAULT now(),
+    updated_at   TIMESTAMPTZ       NOT NULL DEFAULT now(),
+
+    -- Same user cannot have two projects with the same name
+    CONSTRAINT uq_projects_owner_name UNIQUE (owner_id, name)
+);

--- a/crates/alpe-db/migrations/003_audit_log.sql
+++ b/crates/alpe-db/migrations/003_audit_log.sql
@@ -1,0 +1,25 @@
+-- 003_audit_log.sql
+--
+-- Creates the `audit_log` table for recording all significant actions.
+--
+-- Design choices:
+--   • The audit log is append-only — no UPDATE or DELETE should ever be issued
+--     against this table in production.
+--   • `project_id` and `user_id` are nullable because some actions (e.g. system
+--     maintenance) may not be associated with a specific project or user.
+--   • `details` is JSONB for flexible, schema-less payloads (e.g. before/after
+--     snapshots, request metadata) without needing schema migrations for each
+--     new action type.
+--   • No foreign keys on `project_id` / `user_id` — audit entries must survive
+--     even if the referenced entity is deleted.
+
+CREATE TABLE IF NOT EXISTS audit_log (
+    id            UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+    project_id    UUID,
+    user_id       UUID,
+    action        TEXT        NOT NULL,
+    resource_type TEXT,
+    resource_id   UUID,
+    timestamp     TIMESTAMPTZ NOT NULL DEFAULT now(),
+    details       JSONB
+);

--- a/crates/alpe-db/src/error.rs
+++ b/crates/alpe-db/src/error.rs
@@ -1,0 +1,40 @@
+//! Database repository error types.
+//!
+//! Errors are categorized by audience (following the m13-domain-error pattern):
+//! - [`RepositoryError::NotFound`] — user-facing: the requested resource does not exist
+//! - [`RepositoryError::Conflict`] — user-facing: a uniqueness constraint was violated
+//! - [`RepositoryError::Database`] — internal/transient: wraps low-level sqlx errors
+
+/// Errors returned by repository operations.
+///
+/// These are designed to be mapped into HTTP status codes by the API layer:
+/// - `NotFound` → 404
+/// - `Conflict` → 409
+/// - `Database` → 500
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum RepositoryError {
+    /// The requested resource was not found.
+    #[error("resource not found")]
+    NotFound,
+
+    /// A uniqueness constraint was violated (e.g. duplicate project name for the same owner).
+    #[error("conflict: {message}")]
+    Conflict {
+        /// Human-readable description of the conflict.
+        message: String,
+    },
+
+    /// A low-level database error occurred.
+    #[error("database error")]
+    Database(#[from] sqlx::Error),
+}
+
+impl RepositoryError {
+    /// Creates a new conflict error with the given message.
+    pub(crate) fn conflict(message: impl Into<String>) -> Self {
+        Self::Conflict {
+            message: message.into(),
+        }
+    }
+}

--- a/crates/alpe-db/src/lib.rs
+++ b/crates/alpe-db/src/lib.rs
@@ -1,0 +1,45 @@
+//! # alpe-db
+//!
+//! Database migrations, connection pooling, and repository layer for the Alpe platform.
+//!
+//! This crate owns all persistence concerns:
+//! - SQL migrations (embedded via [`sqlx::migrate!`])
+//! - Repository implementations for domain entities
+//! - A typed [`RepositoryError`] hierarchy
+//!
+//! ## Architecture
+//!
+//! Repositories are stateless unit structs with associated async functions that
+//! accept a `&PgPool`. This keeps the data layer aligned with cloud-native
+//! (stateless, horizontally scalable) and web (shared `Arc<PgPool>`) patterns.
+//!
+//! ## Migrations
+//!
+//! Migrations are embedded into the binary at compile time. Call [`run_migrations`]
+//! at application startup to apply them:
+//!
+//! ```rust,ignore
+//! alpe_db::run_migrations(&pool).await?;
+//! ```
+
+/// Database repository error types.
+pub mod error;
+
+/// Project repository — CRUD operations for the `projects` table.
+pub mod project;
+
+pub use error::RepositoryError;
+pub use project::{ProjectRepository, ProjectRow};
+
+/// Runs all pending database migrations against the given pool.
+///
+/// This embeds the migration SQL files from the `migrations/` directory at
+/// compile time, so the binary is self-contained — no external migration files
+/// are needed at runtime.
+///
+/// # Errors
+///
+/// Returns a [`sqlx::migrate::MigrateError`] if any migration fails to apply.
+pub async fn run_migrations(pool: &sqlx::PgPool) -> Result<(), sqlx::migrate::MigrateError> {
+    sqlx::migrate!("./migrations").run(pool).await
+}

--- a/crates/alpe-db/src/project.rs
+++ b/crates/alpe-db/src/project.rs
@@ -1,0 +1,201 @@
+//! Project repository — persistence layer for project CRUD operations.
+//!
+//! All methods are async and take a `&PgPool` as the first argument,
+//! keeping the repository stateless (per cloud-native / domain-web constraints).
+//! Operations that modify data (`create`, `delete`) write an audit log entry
+//! atomically within the same transaction.
+
+use chrono::{DateTime, Utc};
+use sqlx::PgPool;
+use uuid::Uuid;
+
+use alpe_core::jurisdiction::Jurisdiction;
+
+use crate::error::RepositoryError;
+
+/// A project row as stored in the database.
+///
+/// This is the read-side representation returned by all repository queries.
+/// It maps 1:1 to the `projects` table columns.
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct ProjectRow {
+    /// Unique project identifier.
+    pub id: Uuid,
+    /// Project name (unique per owner).
+    pub name: String,
+    /// The jurisdiction this project is bound to.
+    pub jurisdiction: Jurisdiction,
+    /// The user who owns this project.
+    pub owner_id: Uuid,
+    /// When the project was created.
+    pub created_at: DateTime<Utc>,
+    /// When the project was last updated.
+    pub updated_at: DateTime<Utc>,
+}
+
+/// Repository for project persistence operations.
+///
+/// `ProjectRepository` is a unit struct with associated functions — it holds no
+/// state. The database connection pool is passed as a parameter to each method,
+/// following the stateless-service pattern recommended by the `domain-web` and
+/// `domain-cloud-native` skills.
+///
+/// # Transactions
+///
+/// `create` and `delete` use explicit transactions to guarantee that the project
+/// mutation and its corresponding audit log entry are written atomically.
+///
+/// # Errors
+///
+/// All methods return [`RepositoryError`] which categorises failures as:
+/// - `NotFound` — the project does not exist
+/// - `Conflict` — a uniqueness constraint was violated
+/// - `Database` — a low-level sqlx error
+pub struct ProjectRepository;
+
+impl ProjectRepository {
+    /// Creates a new project and records a `"project.created"` audit log entry.
+    ///
+    /// The project is inserted within a transaction together with its audit log
+    /// entry, so either both succeed or neither does.
+    ///
+    /// # Errors
+    ///
+    /// - [`RepositoryError::Conflict`] if a project with the same name already
+    ///   exists for this owner.
+    /// - [`RepositoryError::Database`] on any other database failure.
+    #[tracing::instrument(skip(pool), fields(project_name = %name, owner = %owner_id))]
+    pub async fn create(
+        pool: &PgPool,
+        name: &str,
+        jurisdiction: Jurisdiction,
+        owner_id: Uuid,
+    ) -> Result<ProjectRow, RepositoryError> {
+        let mut tx = pool.begin().await?;
+
+        let row = sqlx::query_as::<_, ProjectRow>(
+            r"
+            INSERT INTO projects (name, jurisdiction, owner_id)
+            VALUES ($1, $2, $3)
+            RETURNING id, name, jurisdiction, owner_id, created_at, updated_at
+            ",
+        )
+        .bind(name)
+        .bind(jurisdiction)
+        .bind(owner_id)
+        .fetch_one(&mut *tx)
+        .await
+        .map_err(|e| match &e {
+            sqlx::Error::Database(db_err)
+                if db_err.constraint() == Some("uq_projects_owner_name") =>
+            {
+                RepositoryError::conflict(format!(
+                    "project with name '{name}' already exists for this owner"
+                ))
+            }
+            _ => RepositoryError::Database(e),
+        })?;
+
+        // Audit log entry
+        sqlx::query(
+            r"
+            INSERT INTO audit_log (project_id, user_id, action, resource_type, resource_id)
+            VALUES ($1, $2, 'project.created', 'project', $3)
+            ",
+        )
+        .bind(row.id)
+        .bind(owner_id)
+        .bind(row.id)
+        .execute(&mut *tx)
+        .await?;
+
+        tx.commit().await?;
+
+        tracing::info!(project_id = %row.id, "project created");
+        Ok(row)
+    }
+
+    /// Returns a project by its unique identifier, or `None` if it doesn't exist.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RepositoryError::Database`] on any database failure.
+    #[tracing::instrument(skip(pool))]
+    pub async fn get_by_id(pool: &PgPool, id: Uuid) -> Result<Option<ProjectRow>, RepositoryError> {
+        let row = sqlx::query_as::<_, ProjectRow>(
+            "SELECT id, name, jurisdiction, owner_id, created_at, updated_at FROM projects WHERE id = $1",
+        )
+        .bind(id)
+        .fetch_optional(pool)
+        .await?;
+
+        Ok(row)
+    }
+
+    /// Lists all projects owned by the given user.
+    ///
+    /// Returns an empty `Vec` if the user has no projects (this is not an error).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RepositoryError::Database`] on any database failure.
+    #[tracing::instrument(skip(pool))]
+    pub async fn list_by_owner(
+        pool: &PgPool,
+        owner_id: Uuid,
+    ) -> Result<Vec<ProjectRow>, RepositoryError> {
+        let rows = sqlx::query_as::<_, ProjectRow>(
+            r"
+            SELECT id, name, jurisdiction, owner_id, created_at, updated_at
+            FROM projects
+            WHERE owner_id = $1
+            ORDER BY created_at ASC
+            ",
+        )
+        .bind(owner_id)
+        .fetch_all(pool)
+        .await?;
+
+        Ok(rows)
+    }
+
+    /// Deletes a project and records a `"project.deleted"` audit log entry.
+    ///
+    /// The deletion and audit log entry are written within a single transaction.
+    ///
+    /// # Errors
+    ///
+    /// - [`RepositoryError::NotFound`] if no project with the given ID exists.
+    /// - [`RepositoryError::Database`] on any other database failure.
+    #[tracing::instrument(skip(pool))]
+    pub async fn delete(pool: &PgPool, id: Uuid, user_id: Uuid) -> Result<(), RepositoryError> {
+        let mut tx = pool.begin().await?;
+
+        let result = sqlx::query("DELETE FROM projects WHERE id = $1")
+            .bind(id)
+            .execute(&mut *tx)
+            .await?;
+
+        if result.rows_affected() == 0 {
+            return Err(RepositoryError::NotFound);
+        }
+
+        // Audit log entry
+        sqlx::query(
+            r"
+            INSERT INTO audit_log (project_id, user_id, action, resource_type, resource_id)
+            VALUES ($1, $2, 'project.deleted', 'project', $3)
+            ",
+        )
+        .bind(id)
+        .bind(user_id)
+        .bind(id)
+        .execute(&mut *tx)
+        .await?;
+
+        tx.commit().await?;
+
+        tracing::info!(%id, "project deleted");
+        Ok(())
+    }
+}

--- a/crates/alpe-db/tests/project_repository.rs
+++ b/crates/alpe-db/tests/project_repository.rs
@@ -1,0 +1,277 @@
+//! Integration tests for `ProjectRepository`.
+//!
+//! Each test spins up an ephemeral Postgres container via [`alpe_test::TestDb`]
+//! and runs against real SQL — no mocking.
+
+#![allow(clippy::expect_used, clippy::unwrap_used, clippy::doc_markdown)]
+
+use alpe_core::jurisdiction::Jurisdiction;
+use alpe_db::{ProjectRepository, RepositoryError};
+
+use uuid::Uuid;
+
+/// Helper: sets up a TestDb and returns the pool + a default test user.
+async fn setup() -> (alpe_test::TestDb, Uuid) {
+    let db = alpe_test::TestDb::new().await;
+    let user_id = db.create_test_user("alice@example.com", "Alice").await;
+    (db, user_id)
+}
+
+// ── CRUD basics ──
+
+#[tokio::test]
+async fn create_project_persists_and_reads_back() {
+    let (db, user_id) = setup().await;
+    let pool = db.pool();
+
+    let created = ProjectRepository::create(pool, "my-project", Jurisdiction::DE, user_id)
+        .await
+        .expect("create should succeed");
+
+    let fetched = ProjectRepository::get_by_id(pool, created.id)
+        .await
+        .expect("get_by_id should succeed")
+        .expect("project should exist");
+
+    assert_eq!(fetched.id, created.id);
+    assert_eq!(fetched.name, "my-project");
+    assert_eq!(fetched.jurisdiction, Jurisdiction::DE);
+    assert_eq!(fetched.owner_id, user_id);
+}
+
+#[tokio::test]
+async fn create_project_sets_timestamps() {
+    let (db, user_id) = setup().await;
+    let pool = db.pool();
+    let before = chrono::Utc::now();
+
+    let created = ProjectRepository::create(pool, "ts-project", Jurisdiction::FR, user_id)
+        .await
+        .expect("create should succeed");
+
+    let after = chrono::Utc::now();
+
+    // Timestamps should be between before and after (with some tolerance)
+    assert!(
+        created.created_at >= before - chrono::Duration::seconds(5),
+        "created_at should be recent"
+    );
+    assert!(
+        created.created_at <= after + chrono::Duration::seconds(5),
+        "created_at should not be in the future"
+    );
+    assert!(
+        created.updated_at >= before - chrono::Duration::seconds(5),
+        "updated_at should be recent"
+    );
+    assert!(
+        created.updated_at <= after + chrono::Duration::seconds(5),
+        "updated_at should not be in the future"
+    );
+}
+
+// ── Listing ──
+
+#[tokio::test]
+async fn list_projects_returns_only_owners_projects() {
+    let db = alpe_test::TestDb::new().await;
+    let pool = db.pool();
+
+    let user_a = db.create_test_user("a@example.com", "User A").await;
+    let user_b = db.create_test_user("b@example.com", "User B").await;
+
+    // User A gets 2 projects
+    ProjectRepository::create(pool, "a-project-1", Jurisdiction::DE, user_a)
+        .await
+        .expect("create a1");
+    ProjectRepository::create(pool, "a-project-2", Jurisdiction::FR, user_a)
+        .await
+        .expect("create a2");
+
+    // User B gets 1 project
+    ProjectRepository::create(pool, "b-project-1", Jurisdiction::IT, user_b)
+        .await
+        .expect("create b1");
+
+    let a_projects = ProjectRepository::list_by_owner(pool, user_a)
+        .await
+        .expect("list A");
+    let b_projects = ProjectRepository::list_by_owner(pool, user_b)
+        .await
+        .expect("list B");
+
+    assert_eq!(a_projects.len(), 2, "User A should have 2 projects");
+    assert_eq!(b_projects.len(), 1, "User B should have 1 project");
+}
+
+#[tokio::test]
+async fn list_projects_returns_empty_for_new_user() {
+    let db = alpe_test::TestDb::new().await;
+    let pool = db.pool();
+
+    // Random UUID that has no projects
+    let random_user = Uuid::new_v4();
+    let projects = ProjectRepository::list_by_owner(pool, random_user)
+        .await
+        .expect("list should succeed");
+
+    assert!(projects.is_empty(), "new user should have no projects");
+}
+
+// ── Get non-existent ──
+
+#[tokio::test]
+async fn get_nonexistent_project_returns_none() {
+    let db = alpe_test::TestDb::new().await;
+    let pool = db.pool();
+
+    let result = ProjectRepository::get_by_id(pool, Uuid::new_v4())
+        .await
+        .expect("get_by_id should succeed");
+
+    assert!(result.is_none(), "non-existent project should return None");
+}
+
+// ── Delete ──
+
+#[tokio::test]
+async fn delete_project_removes_it() {
+    let (db, user_id) = setup().await;
+    let pool = db.pool();
+
+    let created = ProjectRepository::create(pool, "to-delete", Jurisdiction::AT, user_id)
+        .await
+        .expect("create should succeed");
+
+    ProjectRepository::delete(pool, created.id, user_id)
+        .await
+        .expect("delete should succeed");
+
+    let fetched = ProjectRepository::get_by_id(pool, created.id)
+        .await
+        .expect("get_by_id should succeed");
+
+    assert!(fetched.is_none(), "deleted project should be gone");
+}
+
+#[tokio::test]
+async fn delete_nonexistent_project_returns_not_found() {
+    let db = alpe_test::TestDb::new().await;
+    let pool = db.pool();
+
+    let result = ProjectRepository::delete(pool, Uuid::new_v4(), Uuid::new_v4()).await;
+
+    assert!(
+        matches!(result, Err(RepositoryError::NotFound)),
+        "deleting non-existent project should return NotFound"
+    );
+}
+
+// ── Uniqueness constraints ──
+
+#[tokio::test]
+async fn duplicate_project_name_same_owner_rejected() {
+    let (db, user_id) = setup().await;
+    let pool = db.pool();
+
+    ProjectRepository::create(pool, "unique-name", Jurisdiction::DE, user_id)
+        .await
+        .expect("first create should succeed");
+
+    let result = ProjectRepository::create(pool, "unique-name", Jurisdiction::FR, user_id).await;
+
+    assert!(
+        matches!(result, Err(RepositoryError::Conflict { .. })),
+        "duplicate name for same owner should be Conflict, got: {result:?}"
+    );
+}
+
+#[tokio::test]
+async fn duplicate_project_name_different_owner_allowed() {
+    let db = alpe_test::TestDb::new().await;
+    let pool = db.pool();
+
+    let user_a = db.create_test_user("dup-a@example.com", "Dup A").await;
+    let user_b = db.create_test_user("dup-b@example.com", "Dup B").await;
+
+    let result_a = ProjectRepository::create(pool, "shared-name", Jurisdiction::DE, user_a).await;
+    let result_b = ProjectRepository::create(pool, "shared-name", Jurisdiction::DE, user_b).await;
+
+    assert!(result_a.is_ok(), "first user should succeed");
+    assert!(result_b.is_ok(), "second user should also succeed");
+}
+
+// ── Jurisdiction enum mapping ──
+
+#[tokio::test]
+async fn jurisdiction_stored_as_enum() {
+    let (db, user_id) = setup().await;
+    let pool = db.pool();
+
+    let created = ProjectRepository::create(pool, "enum-test", Jurisdiction::DE, user_id)
+        .await
+        .expect("create should succeed");
+
+    let fetched = ProjectRepository::get_by_id(pool, created.id)
+        .await
+        .expect("get_by_id should succeed")
+        .expect("project should exist");
+
+    assert_eq!(
+        fetched.jurisdiction,
+        Jurisdiction::DE,
+        "jurisdiction should roundtrip as DE"
+    );
+}
+
+// ── Audit log ──
+
+#[tokio::test]
+async fn audit_log_written_on_create() {
+    let (db, user_id) = setup().await;
+    let pool = db.pool();
+
+    let created = ProjectRepository::create(pool, "audit-create", Jurisdiction::NL, user_id)
+        .await
+        .expect("create should succeed");
+
+    let log: Vec<(String,)> =
+        sqlx::query_as("SELECT action FROM audit_log WHERE project_id = $1 ORDER BY timestamp")
+            .bind(created.id)
+            .fetch_all(pool)
+            .await
+            .expect("audit query should succeed");
+
+    let actions: Vec<&str> = log.iter().map(|r| r.0.as_str()).collect();
+    assert!(
+        actions.contains(&"project.created"),
+        "audit log should contain 'project.created', got: {actions:?}"
+    );
+}
+
+#[tokio::test]
+async fn audit_log_written_on_delete() {
+    let (db, user_id) = setup().await;
+    let pool = db.pool();
+
+    let created = ProjectRepository::create(pool, "audit-delete", Jurisdiction::ES, user_id)
+        .await
+        .expect("create should succeed");
+
+    ProjectRepository::delete(pool, created.id, user_id)
+        .await
+        .expect("delete should succeed");
+
+    let log: Vec<(String,)> =
+        sqlx::query_as("SELECT action FROM audit_log WHERE project_id = $1 ORDER BY timestamp")
+            .bind(created.id)
+            .fetch_all(pool)
+            .await
+            .expect("audit query should succeed");
+
+    let actions: Vec<&str> = log.iter().map(|r| r.0.as_str()).collect();
+    assert!(
+        actions.contains(&"project.deleted"),
+        "audit log should contain 'project.deleted', got: {actions:?}"
+    );
+}

--- a/crates/alpe-test/src/lib.rs
+++ b/crates/alpe-test/src/lib.rs
@@ -5,8 +5,97 @@
 //! This crate is a **dev-dependency only** — it is never compiled into any
 //! shipped binary. It provides reusable test utilities used across all crates:
 //!
-//! - `TestDb` — spins up an ephemeral Postgres via testcontainers, runs migrations
-//! - `TestApi` — boots the axum server on a random port with a `TestDb`
-//! - `TestUser` — factory for creating test users with specific roles
-//! - `Fixture` — trait for seeding test data
-//! - Assert helpers for API response validation
+//! - [`TestDb`] — spins up an ephemeral Postgres via testcontainers, runs migrations
+//! - `TestApi` — boots the axum server on a random port with a `TestDb` (future)
+//! - `TestUser` — factory for creating test users with specific roles (future)
+//! - `Fixture` — trait for seeding test data (future)
+//! - Assert helpers for API response validation (future)
+
+use sqlx::PgPool;
+use testcontainers::runners::AsyncRunner;
+use testcontainers_modules::postgres::Postgres;
+use uuid::Uuid;
+
+/// An ephemeral Postgres database backed by testcontainers.
+///
+/// `TestDb` spins up a real Postgres container, creates a connection pool,
+/// and runs all `alpe-db` migrations. Each test gets its own isolated database.
+///
+/// # Examples
+///
+/// ```rust,ignore
+/// #[tokio::test]
+/// async fn my_test() {
+///     let db = TestDb::new().await;
+///     let pool = db.pool();
+///     // use pool for queries…
+/// }
+/// ```
+///
+/// The container and database are dropped automatically when `TestDb` goes out
+/// of scope.
+pub struct TestDb {
+    pool: PgPool,
+    // Hold the container handle so it stays alive for the duration of the test.
+    _container: testcontainers::ContainerAsync<Postgres>,
+}
+
+impl TestDb {
+    /// Spins up a new Postgres container and runs all migrations.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the container cannot be started or migrations fail.
+    /// This is intentional — test infrastructure failures should fail loudly.
+    #[allow(clippy::expect_used)]
+    pub async fn new() -> Self {
+        let container = Postgres::default()
+            .start()
+            .await
+            .expect("failed to start Postgres container");
+
+        let host_port = container
+            .get_host_port_ipv4(5432)
+            .await
+            .expect("failed to get Postgres port");
+
+        let connection_string =
+            format!("postgres://postgres:postgres@127.0.0.1:{host_port}/postgres");
+
+        let pool = PgPool::connect(&connection_string)
+            .await
+            .expect("failed to connect to test Postgres");
+
+        alpe_db::run_migrations(&pool)
+            .await
+            .expect("failed to run migrations");
+
+        Self {
+            pool,
+            _container: container,
+        }
+    }
+
+    /// Returns a reference to the connection pool.
+    pub const fn pool(&self) -> &PgPool {
+        &self.pool
+    }
+
+    /// Creates a test user and returns their UUID.
+    ///
+    /// This inserts a minimal user row with a dummy password hash, suitable
+    /// for tests that need an `owner_id` foreign key.
+    #[allow(clippy::expect_used)]
+    pub async fn create_test_user(&self, email: &str, name: &str) -> Uuid {
+        let row: (Uuid,) = sqlx::query_as(
+            "INSERT INTO users (email, name, password_hash) VALUES ($1, $2, '$argon2id$test_hash') RETURNING id",
+        )
+        .bind(email)
+        .bind(name)
+        .fetch_one(&self.pool)
+        .await
+        .expect("failed to create test user");
+
+        row.0
+    }
+}

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -48,6 +48,10 @@ version_group = "alpe"
 publish = false
 
 [[package]]
+name = "alpe-db"
+version_group = "alpe"
+
+[[package]]
 name = "alpe-sdk"
 version_group = "alpe"
 


### PR DESCRIPTION
## Summary

Implements #8 — database migrations and project repository layer.

### What changed

- **New crate: `alpe-db`** — owns all persistence concerns (migrations, repositories, error types)
- **3 SQL migrations**: `users`, `projects` (with Postgres `jurisdiction_type` enum), `audit_log`
- **`ProjectRepository`** — stateless unit struct with `create`, `get_by_id`, `list_by_owner`, `delete`
  - `create`/`delete` are transactional, atomically writing audit log entries
  - Constraint violations map to typed `RepositoryError::Conflict`
- **`RepositoryError`** — typed error hierarchy: `NotFound`, `Conflict`, `Database`
- **`Jurisdiction` sqlx integration** — feature-gated `sqlx::Type/Encode/Decode` impls in `alpe-core` (behind `db` feature)
- **`TestDb`** in `alpe-test` — ephemeral Postgres via testcontainers with migration runner

### Testing

12 integration tests against real Postgres (Docker required):
- CRUD: persist + read back, timestamps, get non-existent
- Ownership: list by owner, empty for new user
- Delete: removes project, not-found on non-existent
- Constraints: duplicate name same owner rejected, different owner allowed
- Enum: jurisdiction roundtrips through Postgres enum
- Audit: log entries written on create and delete

All 12 pass. Workspace clippy + fmt clean.

Closes #8